### PR TITLE
Bug fixes and an addition

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,0 +1,9 @@
+Bug fixes
+
+	Fixed error with missing slash when trying to rename Gamedata directory
+	Fixed errors when one of the buildID.txt or both of the files is missing
+	Fixed error with renaming the buildID.txt files where complete path was being
+	passed in the second argument
+
+Addition
+	Added text for CKAN/registry.locked file, if found, throws an exception

--- a/GameDataSwitcher.sln
+++ b/GameDataSwitcher.sln
@@ -1,9 +1,14 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27130.2010
+VisualStudioVersion = 15.0.26730.8
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GameDataSwitcher", "GameDataSwitcher\GameDataSwitcher.csproj", "{6F21BA69-2C12-4E04-BB2B-8C9924863EA5}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7900B0A9-06A5-44B9-98CC-0C5C9D4E714F}"
+	ProjectSection(SolutionItems) = preProject
+		ChangeLog.txt = ChangeLog.txt
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/GameDataSwitcher/MainWindow.cs
+++ b/GameDataSwitcher/MainWindow.cs
@@ -237,7 +237,7 @@ namespace GameDataSwitcher
             #endregion
 
             //rewrite GameDataData.data
-            StreamWriter dataFile = new StreamWriter(LOC + GamedataList[List.SelectedIndex] + "/GameDataData.data");
+            StreamWriter dataFile = new StreamWriter(LOC + "/" + GamedataList[List.SelectedIndex] + "/GameDataData.data");
             dataFile.Write(newname);
             dataFile.Close();
             
@@ -273,8 +273,17 @@ namespace GameDataSwitcher
                     catch { }
                 }
                 //buildID
-                Microsoft.VisualBasic.FileIO.FileSystem.RenameFile(LOC + "/" + GameDataDataInformation.Text + "_buildID.txt", LOC + "/" + newname + "_buildID.txt");
-                Microsoft.VisualBasic.FileIO.FileSystem.RenameFile(LOC + "/" + GameDataDataInformation.Text + "_buildID64.txt", LOC + "/" + newname + "_buildID64.txt");
+                try
+                {
+                    Microsoft.VisualBasic.FileIO.FileSystem.RenameFile(LOC + "/" + GameDataDataInformation.Text + "_buildID.txt",  newname + "_buildID.txt");
+                }
+                catch { }
+                try
+                {
+                    if (Environment.Is64BitOperatingSystem)
+                        Microsoft.VisualBasic.FileIO.FileSystem.RenameFile(LOC + "/" + GameDataDataInformation.Text + "_buildID64.txt",  newname + "_buildID64.txt");
+                }
+                catch { }
             }
 
             //Message box
@@ -339,10 +348,15 @@ namespace GameDataSwitcher
             }
 
             //buildID
-            Microsoft.VisualBasic.FileIO.FileSystem.CopyFile(LOC + "/buildID.txt", LOC + "/" + newFolderName + "_buildID.txt", true);
+            try
+            { 
+                Microsoft.VisualBasic.FileIO.FileSystem.CopyFile(LOC + "/buildID.txt", LOC + "/" + newFolderName + "_buildID.txt", true);
+            }
+            catch { }
             try
             {
-                Microsoft.VisualBasic.FileIO.FileSystem.CopyFile(LOC + "/buildID64.txt", LOC + "/" + newFolderName + "_buildID64.txt", true);
+                if (Environment.Is64BitOperatingSystem)
+                    Microsoft.VisualBasic.FileIO.FileSystem.CopyFile(LOC + "/buildID64.txt", LOC + "/" + newFolderName + "_buildID64.txt", true);
             }
             catch { }
 
@@ -357,6 +371,14 @@ namespace GameDataSwitcher
         private void SetAsDefault_Click(object sender, EventArgs e)//set as default
         {
             string folderName;
+
+            // Test for a locked registry, if so, abort
+            if (Directory.Exists(LOC + "/CKAN") && File.Exists(LOC + "/CKAN/registry.locked"))
+            {
+                throw new System.InvalidOperationException("GameData cannot be changed while CKAN is open");
+                return;
+            }
+
             //make backup logs 
             #region make backup logs
             try
@@ -413,9 +435,17 @@ namespace GameDataSwitcher
                                            
                     }
                     //buildID
-                    Microsoft.VisualBasic.FileIO.FileSystem.RenameFile(LOC + "/buildID.txt", folderName + "_buildID.txt");
-                    if (Environment.Is64BitOperatingSystem)
-                        Microsoft.VisualBasic.FileIO.FileSystem.RenameFile(LOC + "/buildID64.txt", folderName + "_buildID64.txt");
+                    try
+                    { 
+                        Microsoft.VisualBasic.FileIO.FileSystem.RenameFile(LOC + "/buildID.txt", folderName + "_buildID.txt");
+                    }
+                    catch { }
+                    try
+                    {
+                        if (Environment.Is64BitOperatingSystem)
+                            Microsoft.VisualBasic.FileIO.FileSystem.RenameFile(LOC + "/buildID64.txt", folderName + "_buildID64.txt");
+                    }
+                    catch { }
                 }               
             }
 
@@ -456,12 +486,19 @@ namespace GameDataSwitcher
             }
 
             //buildID
-            Microsoft.VisualBasic.FileIO.FileSystem.RenameFile(GameDataDataInformation.Text + "_buildID.txt", "buildID.txt");
-            if (Environment.Is64BitOperatingSystem)
-                Microsoft.VisualBasic.FileIO.FileSystem.RenameFile(GameDataDataInformation.Text + "_buildID64.txt", "buildID64.txt");
-
+            try
+            { 
+                Microsoft.VisualBasic.FileIO.FileSystem.RenameFile(GameDataDataInformation.Text + "_buildID.txt", "buildID.txt");
+            }
+            catch { }
+            try
+            {
+                if (Environment.Is64BitOperatingSystem)
+                    Microsoft.VisualBasic.FileIO.FileSystem.RenameFile(GameDataDataInformation.Text + "_buildID64.txt", "buildID64.txt");
+            }
+            catch { }
             //done.
-            Microsoft.VisualBasic.Interaction.MsgBox("Done.\n" + GamedataList[List.SelectedIndex] + " already set as the default GameData.\n" + "saves_" + GameDataDataInformation.Text + " already set as the default Saves.\nAlready made backup for all logs", Microsoft.VisualBasic.MsgBoxStyle.Information, "Set as Default");
+            Microsoft.VisualBasic.Interaction.MsgBox("Done.\n" + GamedataList[List.SelectedIndex] + " set as the default GameData.\n" + "saves_" + GameDataDataInformation.Text + " set as the default Saves.\nMade backup for all logs", Microsoft.VisualBasic.MsgBoxStyle.Information, "Set as Default");
             ReloadList();            
         }
 
@@ -497,10 +534,16 @@ namespace GameDataSwitcher
             dataFile.Close();
 
             //buildID
-            Microsoft.VisualBasic.FileIO.FileSystem.CopyFile(LOC + "/buildID.txt", LOC + "/" + newFolderName + "_buildID.txt", true);
+            try
+            { 
+                Microsoft.VisualBasic.FileIO.FileSystem.CopyFile(LOC + "/buildID.txt", LOC + "/" + newFolderName + "_buildID.txt", true);
+            }
+            catch { }
+
             try
             {
-                Microsoft.VisualBasic.FileIO.FileSystem.CopyFile(LOC + "/buildID64.txt", LOC + "/" + newFolderName + "_buildID64.txt", true);
+                if (Environment.Is64BitOperatingSystem)
+                    Microsoft.VisualBasic.FileIO.FileSystem.CopyFile(LOC + "/buildID64.txt", LOC + "/" + newFolderName + "_buildID64.txt", true);
             }
             catch { }
 
@@ -544,8 +587,16 @@ namespace GameDataSwitcher
                 {
                     Microsoft.VisualBasic.FileIO.FileSystem.DeleteDirectory(LOC + "/GameData_" + GameDataDataInformation.Text,Microsoft.VisualBasic.FileIO.DeleteDirectoryOption.DeleteAllContents);
                     Microsoft.VisualBasic.FileIO.FileSystem.DeleteDirectory(LOC + "/saves_" + GameDataDataInformation.Text, Microsoft.VisualBasic.FileIO.DeleteDirectoryOption.DeleteAllContents);
-                    Microsoft.VisualBasic.FileIO.FileSystem.DeleteFile(LOC + "/" + GameDataDataInformation.Text + "_buildID.txt");
-                    Microsoft.VisualBasic.FileIO.FileSystem.DeleteFile(LOC + "/" + GameDataDataInformation.Text + "_buildID64.txt");
+                    try
+                    {
+                        Microsoft.VisualBasic.FileIO.FileSystem.DeleteFile(LOC + "/" + GameDataDataInformation.Text + "_buildID.txt");
+                    }
+                    catch { }
+                    try
+                    {
+                        Microsoft.VisualBasic.FileIO.FileSystem.DeleteFile(LOC + "/" + GameDataDataInformation.Text + "_buildID64.txt");
+                    }
+                    catch { }
                     if (Directory.Exists(LOC + "/CKAN"))
                     {
                         /*


### PR DESCRIPTION
Bug fixes
	Fixed error with missing slash when trying to rename Gamedata directory
	Fixed errors when one of the buildID.txt or both of the files is missing
	Fixed error with renaming the buildID.txt files where complete path was being passed in the second argument

Addition
	Added text for CKAN/registry.locked file, if found, throws an exception